### PR TITLE
Release 0.9.7

### DIFF
--- a/Core/HCS_CalculateScore.lua
+++ b/Core/HCS_CalculateScore.lua
@@ -39,12 +39,17 @@ local function CompareStats(beforeStats, scores, descriptions)
     for key, value in pairs(beforeStats) do
         local desc = descriptions[key] or key -- Use the matched description if available, otherwise use the key itself
 
-        
         if key ~= "coreScore" and beforeStats[key] ~= scores[key]  then
             -- Values are different, do something            
             local difference = scores[key] - beforeStats[key]
             local formatted_time = date("%H:%M:%S")
-            local msg = "[" .. formatted_time .. "] " .. (desc) .. " " .. string.format("%.3f", difference) .. " pts"
+            local msg = ""
+            local showTimestamp = Hardcore_Score.db.profile.framePositionLog.showTimestamp
+            if showTimestamp then
+                msg = "[" .. formatted_time .. "] " .. (desc) .. " " .. string.format("%.3f", difference) .. " pts"
+            else
+                msg = (desc) .. " " .. string.format("%.3f", difference) .. " pts"
+            end
             HCS_PointsLogUI:AddMessage(msg)
         end
     end
@@ -91,12 +96,14 @@ end
 
 local function LeveledUp(points)
 
-    if Hardcore_Score.db.profile.framePositionMsg.show then    
+    if Hardcore_Score.db.profile.framePositionMsg.show then
         local playerLevel = UnitLevel("player")
+        if playerLevel < HCScore_Character.level then
+            playerLevel = playerLevel + 1 
+        end
         local msg = "Level Up! You reached level "..playerLevel
-
         local frame = HCS_MessageFrameUI.DisplayMessage(msg, 10, Img_hcs_levelupframe_32)
-        frame:ShowMessage() 
+        frame:ShowMessage()
 
        -- local msg = "You just gained "..string.format("%.3f",points).." pts by leveling!"
        -- local frame = HCS_MessageFrameUI.DisplayMessage(msg, 10, Img_hcs_levelupframe_32)
@@ -105,7 +112,6 @@ local function LeveledUp(points)
     
     HCS_PlayerLevelingScore:SaveLevelScore()
     PlayerLeveled = false
-
 end
 
 function HCS_CalculateScore:RefreshScores(desc)
@@ -118,8 +124,8 @@ function HCS_CalculateScore:RefreshScores(desc)
 
     HCS_MilestonesScore:CheckMilestones()
 
-    HCScore_Character.scores.equippedGearScore = HCS_PlayerEquippedGearScore:GetEquippedGearScore() * levelScalePercentage
     HCScore_Character.scores.levelingScore = HCS_PlayerLevelingScore:GetLevelScore() * levelScalePercentage
+    HCScore_Character.scores.equippedGearScore = HCS_PlayerEquippedGearScore:GetEquippedGearScore() * levelScalePercentage
     HCScore_Character.scores.professionsScore = HCS_ProfessionsScore:GetProfessionsScore() * levelScalePercentage
     HCScore_Character.scores.reputationScore = HCS_ReputationScore:GetReputationScore() * (levelScalePercentage ^ 2)
     HCScore_Character.scores.discoveryScore = HCS_DiscoveryScore:GetDiscoveryScore() * levelScalePercentage
@@ -134,8 +140,8 @@ function HCS_CalculateScore:RefreshScores(desc)
     if desc ~= nil then
         CompareStats(beforeStats, HCScore_Character.scores, desc)
     end
-
-    if PlayerLeveled then 
+ 
+    if PlayerLeveled  then 
       local scorebefore = beforeStats.coreScore
       local scoreafter = HCScore_Character.scores.coreScore
       local scorediff = scoreafter - scorebefore

--- a/Core/HCS_PlayerLevelingScore.lua
+++ b/Core/HCS_PlayerLevelingScore.lua
@@ -67,7 +67,7 @@ function HCS_PlayerLevelingScore:GetLevelScore()
     
     local score = 0
     local level = UnitLevel("player")
-    HCScore_Character.level  = level
+    HCScore_Character.level = level
     
     score = data[level].Total
 
@@ -76,7 +76,7 @@ function HCS_PlayerLevelingScore:GetLevelScore()
 end
 
 function HCS_PlayerLevelingScore:SaveLevelScore()
-    local playerLevel = UnitLevel("player") - 1
+    local playerLevel = HCScore_Character.level - 1
     local isLevelfound = false
 
     for _, lvl in pairs(HCScore_Character.levelScores) do

--- a/Hardcore_Score.lua
+++ b/Hardcore_Score.lua
@@ -7,7 +7,7 @@ local _;
 Hardcore_Score = {}
 
 -- Globals
-HCS_Version = "0.9.6" --GetAddOnMetadata("Hardcore Score", "Version")
+HCS_Version = "0.9.7" --GetAddOnMetadata("Hardcore Score", "Version")
 HCScore_Character = {
     name = "",
     class = "",
@@ -65,50 +65,75 @@ local options = {
             set = function(info,val) Hardcore_Score.db.profile.shareDetails = val end,  -- update your set function
             get = function(info) return Hardcore_Score.db.profile.shareDetails end  -- update your get function
         },
+        showMessages = {
+            name = "Show Messages",
+            desc = "Enables / disables reward messages",
+            type = "toggle",
+            order = 2,
+            set = function(info,val) 
+                    Hardcore_Score.db.profile.framePositionMsg.show = val 
+                end,  -- update your set function
+            get = function(info) return Hardcore_Score.db.profile.framePositionMsg.show end  -- update your get function
+        },
+        Space1 = {
+            name = "",
+            desc = "",
+            type = "description",
+            fontSize = "medium",
+            order = 3
+        },
+        PointsLogHeader = {
+            name = "Points Log",
+            type = "header",
+            order = 4
+        },
         showPointsLog = {
             name = "Show Points Log",
             desc = "Enables / disables showing Points Log",
             type = "toggle",
-            order = 2,
+            order = 5,
             set = function(info,val) 
                     Hardcore_Score.db.profile.framePositionLog.show = val 
                     HCS_PointsLogUI:SetVisibility()
                 end,  -- update your set function
             get = function(info) return Hardcore_Score.db.profile.framePositionLog.show end  -- update your get function
         },
-        showMessages = {
-            name = "Show Messages",
-            desc = "Enables / disables reward messages",
+        showPointsLogTimeStamp = {
+            name = "Show Timestamp",
+            desc = "Displays showing the timestamp in Points log",
             type = "toggle",
-            order = 3,
-            set = function(info,val) 
-                    Hardcore_Score.db.profile.framePositionMsg.show = val 
-                end,  -- update your set function
-            get = function(info) return Hardcore_Score.db.profile.framePositionMsg.show end  -- update your get function
+            order = 6,
+            set = function(info,val) Hardcore_Score.db.profile.framePositionLog.showTimestamp = val end,
+            get = function(info) return Hardcore_Score.db.profile.framePositionLog.showTimestamp end
         },
- --[[
-        setMessageslocation = {
-            name = "Set Location",
-            desc = "Sets the location of where the messages show up",
-            type = "execute",
-            order = 4,
-            func = function() 
-                    local frame = HCS_MessageFrameUI.DisplayMessage("Your message here", 5) -- Display for 5 seconds
-                    frame:ShowMessage() -- Manually trigger the message display                       
-                end,
+
+        editBoxFontSize = {
+            name = "Font Size",
+            desc = "Adjusts the font size in the Points Log edit box",
+            type = "range",
+            order = 7,
+            min = 10,
+            max = 24,
+            step = 1,
+            set = function(info,val)
+                Hardcore_Score.db.profile.framePositionLog.fontSize = val
+                local fontName, _, fontFlags = HCS_PointsLogUI.EditBox:GetFont()
+                HCS_PointsLogUI.EditBox:SetFont(fontName, val, fontFlags)
+            end,
+            get = function(info) return Hardcore_Score.db.profile.framePositionLog.fontSize end
         },
-]]        
-        Space1 = {
+
+        Space2 = {
             name = "",
             desc = "",
             type = "description",
             fontSize = "medium",
-            order = 5
+            order = 8
         },
         LinksHeader = {
             name = "Connect for more information",
             type = "header",
-            order = 6
+            order = 9
         },
         twitterLink = {
             name = " Follow us on Twitter at https://twitter.com//HardcoreScore",
@@ -116,7 +141,7 @@ local options = {
             type = "description",
             fontSize = "medium",
             image = "Interface\\Addons\\Hardcore_Score\\Media\\TwitterLogo.blp",
-            order = 7
+            order = 10
         },
         discordLink = {
             name = " Join our Discord server at https://discord.gg/j92hrVZU2Q",
@@ -124,7 +149,7 @@ local options = {
             type = "description",
             fontSize = "medium",
             image = "Interface\\Addons\\Hardcore_Score\\Media\\DiscordLogo.blp",
-            order = 8
+            order = 11
         },
         websiteLink = {
             name = " Website  https://avenroothcs.wixsite.com/hardcore-score",
@@ -132,28 +157,8 @@ local options = {
             type = "description",
             fontSize = "medium",
             image = "Interface\\Addons\\Hardcore_Score\\Media\\www_icon.blp",
-            order = 9
-        },
-        Space2 = {
-            name = "",
-            desc = "",
-            type = "description",
-            fontSize = "medium",
-            order = 10
-        },
-
-        addonInfoHeader = {
-            name = "Note from the author",
-            type = "header",
-            order = 11
-        },
-        addonInfo1 = {
-            name = "Thank you for trying out Hardcore Score. We are still in beta process and are aware of a few issues we are ironing out. We wanted to get this into your hands to get some feedback on what you think and let us know what changes you would like. If you find a bug please report it to our Discord.",
-            desc = "Addon Information",
-            type = "description",
-            fontSize = "medium",
             order = 12
-        },            
+        },
         Space3 = {
             name = "",
             desc = "",
@@ -161,27 +166,47 @@ local options = {
             fontSize = "medium",
             order = 13
         },
-        addonInfo2 = {
-            name = "We have a lot of things we would like to do with Hardcore Score. We are excited to share those with you soon. Please be patient with us as we work out any issues in this beta. Enjoy challenging yourself to get the best Hardcore Score possible and share your results with us. Thank you and have fun!!",
+
+        addonInfoHeader = {
+            name = "Note from the author",
+            type = "header",
+            order = 14
+        },
+        addonInfo1 = {
+            name = "Thank you for trying out Hardcore Score. We are still in beta process and are aware of a few issues we are ironing out. We wanted to get this into your hands to get some feedback on what you think and let us know what changes you would like. If you find a bug please report it to our Discord.",
             desc = "Addon Information",
             type = "description",
             fontSize = "medium",
-            order = 14
+            order = 15
         },            
-
         Space4 = {
             name = "",
             desc = "",
             type = "description",
             fontSize = "medium",
-            order = 12
+            order = 16
+        },
+        addonInfo2 = {
+            name = "We have a lot of things we would like to do with Hardcore Score. We are excited to share those with you soon. Please be patient with us as we work out any issues in this beta. Enjoy challenging yourself to get the best Hardcore Score possible and share your results with us. Thank you and have fun!!",
+            desc = "Addon Information",
+            type = "description",
+            fontSize = "medium",
+            order = 17
+        },            
+
+        Space5 = {
+            name = "",
+            desc = "",
+            type = "description",
+            fontSize = "medium",
+            order = 18
         },
         addonInfoNote = {
             name = "* Note - Although we encourage you to use the Hardcore Addon with Hardcore Score, we are not accociated with the Hardcore Addon team.",
             desc = "Addon Information",
             type = "description",
             fontSize = "medium",
-            order = 13
+            order = 19
         },            
 
     },
@@ -272,6 +297,7 @@ function Hardcore_Score:CreateDB()
                 xOfs = 0,
                 yOfs = 0,
             },
+            -- Points Log
             framePositionLog = {
                 point = "CENTER",  --"CENTER",
                 relativeTo = "UIParent",
@@ -279,7 +305,10 @@ function Hardcore_Score:CreateDB()
                 xOfs = 0,
                 yOfs = 0,
                 show = false,
+                showTimestamp = true,
+                fontSize = 14,
             },
+            -- Notification / Message 
             framePositionMsg = {
                 point = "CENTER",  --"CENTER",
                 relativeTo = "UIParent",
@@ -302,21 +331,7 @@ function Hardcore_Score:CreateMiniMapButton()
         type = "launcher",
         icon = "Interface\\Addons\\Hardcore_Score\\Media\\hcs-minimap-16.blp",  -- XP_ICON, Spell_Nature_Polymorph
         OnClick = function(self, button)
-            -- Add OnClick code here
-            --HCS_MessageFrameUI.DisplayMessage("This is a test message!")
---[[
-            if Hardcore_Score.db.profile.framePositionMsg.show then
-                local frame = HCS_MessageFrameUI.DisplayMessage("Milestone! You have killed 500 mobs", 5, Img_hcs_milestoneframedark_32) -- Display for 5 seconds
-                frame:ShowMessage() -- Manually trigger the message display
-
-                local frame = HCS_MessageFrameUI.DisplayMessage("Milestone! You reached for level 55", 5, Img_hcs_milestoneframedark_32) -- Display for 5 seconds
-                frame:ShowMessage() -- Manually trigger the message display
-
-                local frame = HCS_MessageFrameUI.DisplayMessage("Level 55! You gained 1000.00 pts", 5, Img_hcs_levelupframe_32) -- Display for 5 seconds
-                frame:ShowMessage() -- Manually trigger the message display
-            end
-]]
-            --HCS_WelcomeUI:ToggleMyFrame()            
+            -- Add OnClick code here          
             HCS_PointsLogUI:ToggleMyFrame()
         end,        
 
@@ -344,83 +359,104 @@ function Hardcore_Score:LoadSavedFramePosition()
     end
 end
 
--- WARNING: self automatically becomes events frame!
 function Hardcore_Score:init(event, name)
-    if (name ~= "Hardcore_Score") then return end
+    if event == "ADDON_LOADED" then
+        if name ~= "Hardcore_Score" then return end
 
-    -- allows using left and right buttons to move through chat 'edit' box
-    for i = 1, NUM_CHAT_WINDOWS do
-        _G["ChatFrame"..i.."EditBox"]:SetAltArrowKeyMode(false);
+        -- allows using left and right buttons to move through chat 'edit' box
+        for i = 1, NUM_CHAT_WINDOWS do
+            _G["ChatFrame"..i.."EditBox"]:SetAltArrowKeyMode(false);
+        end
+
+        -- Register Slash Commands!
+        SLASH_RELOADUI1 = "/rl"; -- new slash command for reloading UI
+        SlashCmdList.RELOADUI = ReloadUI;
+
+        SLASH_FRAMESTK1 = "/fs"; -- new slash command for showing framestack tool
+        SlashCmdList.FRAMESTK = function ()
+            LoadAddOn("Blizzard_DebugTools");
+            FrameStackTooltip_Toggle();        
+        end
+
+        -- initalization Hardcore_Score_Settings
+        if Hardcore_Score_Settings == nil then Hardcore_Score_Settings = {} end
+
+        HCS_Playerinfo:LoadCharacterData()
+        --print("LoadCharacterData")
+
+        HCS_ScoreboardSummaryUI:CreateFrame()
+        --print("HCS_ScoreboardSummaryUI:Create")
+
+        Hardcore_Score:CreateDB()
+        --print("CreateDB")
+
+        -- Create minimap button
+        Hardcore_Score:CreateMiniMapButton()
+        --print("CreateMiniMapButton")
+
+        -- Get frame saved position
+        Hardcore_Score:LoadSavedFramePosition()    
+        --print("LoadSavedFramePosition")
+
+        -- Register the options table
+        AceConfig:RegisterOptionsTable("Hardcore_Score", options)
+        --print("RegisterOptionsTable")
+
+        -- Add the options table to the Blizzard interface options
+        AceConfigDialog:AddToBlizOptions("Hardcore_Score", "Hardcore Score")
+        --print("AddToBlizOptions")
+
+        HCS_PointsLogUI:SetVisibility()
+
+        HCS_PlayerCompletingQuestEvent:RecalculateQuests()
+
+        HCS_CalculateScore:RefreshScores()
+
+    elseif event == "PLAYER_LOGIN" then
+        local playerName
+        local fontSize = Hardcore_Score.db.profile.framePositionLog.fontSize
+        local showTimestamp = Hardcore_Score.db.profile.framePositionLog.showTimestamp
+        if fontSize == nil then
+            fontSize = 14  -- save the default value 
+            Hardcore_Score.db.profile.framePositionLog.fontSize = fontSize  -- save the default value
+        end
+        if showTimestamp == nil then
+            Hardcore_Score.db.profile.framePositionLog.showTimestamp = true
+        end
+        local fontName, _, fontFlags = HCS_PointsLogUI.EditBox:GetFont()
+        HCS_PointsLogUI.EditBox:SetFont(fontName, fontSize, fontFlags)
+
+
+        if HCScore_Character.class == "Druid" then 
+            playerName = "|cFFFF7C0A"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Hunter" then
+            playerName = "|cFFAAD372"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Mage" then
+            playerName = "|cFF3FC7EB"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Paladin" then
+            playerName = "|cFFF48CBA"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Priest" then
+            playerName = "|cFFFFFFFF"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Rouge" then
+            playerName = "|cFFFFF468"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Shaman" then
+            playerName = "|cFF0070DD"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Warlock" then
+            playerName = "|cFF8788EE"..HCScore_Character.name.."|r"
+        elseif HCScore_Character.class == "Warrior" then
+            playerName = "|cFFC69B6D"..HCScore_Character.name.."|r"
+        end
+
+        -- Print fun stuff for the player
+        print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome "..playerName.." to Hardcore Score v0.9.7.  Lets GO!")
+        --print("|cff81b7e9".."Hardcore Score: ".."|r".."Psst,", playerName.. "! "..  string.format("%.2f", HCS_PlayerCoreScore:GetCoreScore()).. " is a great score!");   
+
     end
 
-    -- Register Slash Commands!
-    SLASH_RELOADUI1 = "/rl"; -- new slash command for reloading UI
-    SlashCmdList.RELOADUI = ReloadUI;
-
-    -- Register Slash Commands!
---    SLASH_GETGEARINFO1 = "/gearinfo"; -- new slash command for getting gearinfo
---    SlashCmdList.SLASH_GETGEARINFO = HCS_PlayerEquippedGearScore:GetEquippedGearScore()
-    
-    SLASH_FRAMESTK1 = "/fs"; -- new slash command for showing framestack tool
-    SlashCmdList.FRAMESTK = function ()
-        LoadAddOn("Blizzard_DebugTools");
-        FrameStackTooltip_Toggle();        
-    end
-
---    SLASH_HCS_ScoreboardUI1 = "/lb";
---    SlashCmdList.HCS_ScoreboardUI = HandleSlashCommands;
-
-    -- Load the saved variables data for your addon
- --   HCScore_Character = _G[ADDON_NAMESPACE] or {}
-
-    -- Set the default values for your addon's saved variables
---    HCScore_StoredVariables = HCScore_StoredVariables or {}
-
-    -- Save the updated values back to the store variables file
---    _G[ADDON_NAMESPACE] = HCScore_StoredVariables
- --   CharacterInfo = HCScore_StoredVariables.CharacterInfo
-    
-    -- initalization Hardcore_Score_Settings
-    if Hardcore_Score_Settings == nil then Hardcore_Score_Settings = {} end
-
-    HCS_Playerinfo:LoadCharacterData()
-    --print("LoadCharacterData")
-
-    HCS_ScoreboardSummaryUI:CreateFrame()
-    --print("HCS_ScoreboardSummaryUI:Create")
-
-    Hardcore_Score:CreateDB()
-    --print("CreateDB")
-
-    -- Create minimap button
-    Hardcore_Score:CreateMiniMapButton()
-    --print("CreateMiniMapButton")
-
-    -- Get frame saved position
-    Hardcore_Score:LoadSavedFramePosition()    
-    --print("LoadSavedFramePosition")
-    
-    -- Register the options table
-    AceConfig:RegisterOptionsTable("Hardcore_Score", options)
-    --print("RegisterOptionsTable")
-
-    -- Add the options table to the Blizzard interface options
-    AceConfigDialog:AddToBlizOptions("Hardcore_Score", "Hardcore Score")
-    --print("AddToBlizOptions")
-
-    HCS_PointsLogUI:SetVisibility()
-
-    HCS_PlayerCompletingQuestEvent:RecalculateQuests()
-    
-    HCS_CalculateScore:RefreshScores()
-
-    -- Print fun stuff for the player
-    print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome to Hardcore Score v0.9.6.  Lets GO!")
---    Hardcore_Score:Print("Psst, ", UnitName("player").. "! "..  string.format("%.2f", HCScore_Character.scores.coreScore).. " is a great score! LET'S GO!");
-    --print("Psst, ", UnitName("player").. "! "..  string.format("%.2f", HCS_PlayerCoreScore:GetCoreScore()).. " is a great score! LET'S GO!");   
 end
 
 local events = CreateFrame("Frame");
 events:RegisterEvent("ADDON_LOADED");
+events:RegisterEvent("PLAYER_LOGIN")
 events:SetScript("OnEvent", Hardcore_Score.init);
 

--- a/Hardcore_Score.toc
+++ b/Hardcore_Score.toc
@@ -1,8 +1,8 @@
 ## Interface: 11403
-## Title: Hardcore Score 0.9.6
+## Title: Hardcore Score 0.9.7
 ## Notes: Your Hardcore score for your character
 ## Author: Avenroot
-## Version: 0.9.6
+## Version: 0.9.7
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/UI/HCS_PointsLogUI.lua
+++ b/UI/HCS_PointsLogUI.lua
@@ -1,3 +1,4 @@
+-- Globals / Namespace
 HCS_PointsLogUI = {}
 
 -- Create a table to store chat history
@@ -54,6 +55,7 @@ end)
 -- Create a close button
 local closeButton = CreateFrame("Button", nil, frame, "UIPanelCloseButton")
 closeButton:SetPoint("TOPRIGHT")
+closeButton:Hide()
 
 -- Create a scrollframe
 local scrollFrame = CreateFrame("ScrollFrame", nil, frame, "UIPanelScrollFrameTemplate")
@@ -61,12 +63,12 @@ scrollFrame:SetPoint("TOPLEFT", 16, -32)  -- Adjust the position to leave space 
 scrollFrame:SetPoint("BOTTOMRIGHT", -30, 16)
 
 -- Create an edit box for multi-line text
-local editBox = CreateFrame("EditBox", nil, scrollFrame)
-editBox:SetMultiLine(true)
-editBox:SetFontObject(ChatFontNormal)
-editBox:SetWidth(250)
-editBox:Disable()  -- This makes the text read-only
-scrollFrame:SetScrollChild(editBox)
+HCS_PointsLogUI.EditBox = CreateFrame("EditBox", nil, scrollFrame)
+HCS_PointsLogUI.EditBox:SetMultiLine(true)
+HCS_PointsLogUI.EditBox:SetFontObject(ChatFontNormal)
+HCS_PointsLogUI.EditBox:SetWidth(250)
+HCS_PointsLogUI.EditBox:Disable()  -- This makes the text read-only
+scrollFrame:SetScrollChild(HCS_PointsLogUI.EditBox)
 
 -- Function to toggle frame visibility
 function HCS_PointsLogUI:ToggleMyFrame()
@@ -97,7 +99,7 @@ function HCS_PointsLogUI:AddMessage(msg)
     end
 
     -- Update the text in the editBox
-    editBox:SetText(table.concat(self.chatHistory, "\n"))
+    HCS_PointsLogUI.EditBox:SetText(table.concat(self.chatHistory, "\n"))
 
     -- Scroll to the bottom
     C_Timer.After(0.1, function()  -- Slightly delay to let the UI update first
@@ -113,8 +115,8 @@ end
 frame:SetScript("OnSizeChanged", function(self, width, height)
     scrollFrame:SetWidth(width - 36)
     scrollFrame:SetHeight(height - 50)
-    editBox:SetWidth(width - 36)
-    editBox:SetHeight(height - 50)
+    HCS_PointsLogUI.EditBox:SetWidth(width - 36)
+    HCS_PointsLogUI.EditBox:SetHeight(height - 50)
 end)
 
 -- Create a resize button

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,19 +1,24 @@
 Version 0.9.1
     Initial release
+
 Version 0.9.2
     Fixed Points log scrolling. Newest entry shows correctly.
     Updated some text in the Points log.
     Now see 3 digits of detail instead of 2 in the Points log.
     Fixed Sharing Detals option.
+
 Version 0.9.3
     Professions - No longer do you lose points when untraining a profession and re-learning it.
+
 Version 0.9.4
     Deleting a character and creating a new one with the same name will reset points correctly.
+
 Version 0.9.5
     Added website link to options (https://avenroothcs.wixsite.com/hardcore-score)
     Added a new messaging system.  Milestones and gaining levels now have a reward message show on the screen. Messaging can be turned on/off in options.
     Added Portraits.  You can get a new portrait to show on your Hardscore summary circle.  There are 7 different portraits you can unlock.
         Portraits are Grey, Green, Blue, Purple, Orange, Diamond Ruby, Gold Crown.  Have fun unlocking them all.
+
 Version 0.9.6
     1. Updated Messaging/Notification system significantly.
         You should see more details in the points log.  Especially when leveling.
@@ -24,5 +29,11 @@ Version 0.9.6
     4.  Set the Message Frame Priority to "MEDIUM" to show on top of other HCS frames.
     5.  Addon now tracks how many points gained for each level and keeps a history of it.
     
-        
+Version 0.9.7
+    1. Hide the close button on the Points Log.  Can open and close it from the options or clicking on them minimap icon.
+    2. *Fixed a reported issue where Notification Message is one level behind when leveling.
+    3. Added option to now show timestamps in the points log.
+    4. Added option to change the points log font.
+    5. Minor bug fixes and code updates.        
+* This is still an issue in some cases.  We continue to investigate. It is just a display issue with Milestones. Points are calculated with the correct level.
     


### PR DESCRIPTION
Version 0.9.7
    1. Hide the close button on the Points Log.  Can open and close it from the options or clicking on them minimap icon.
    2. *Fixed a reported issue where Notification Message is one level behind when leveling.
    3. Added option to now show timestamps in the points log.
    4. Added option to change the points log font.
    5. Minor bug fixes and code updates.        
* This is still an issue in some cases.  We continue to investigate. It is just a display issue with Milestones. Points are calculated with the correct level.