### PR TITLE
Release 0.9.11

### DIFF
--- a/Core/HCS_CalculateScore.lua
+++ b/Core/HCS_CalculateScore.lua
@@ -133,13 +133,9 @@ local function LeveledUp(points)
 
     local playerLevel = UnitLevel("player")
 
-    if Hardcore_Score.db.profile.framePositionMsg.show then
-        
-        --if playerLevel < HCScore_Character.level then
-        --    playerLevel = playerLevel + 1 
-        --end
+    if Hardcore_Score.db.profile.framePositionMsg.show then       
         local msg = "Level "..playerLevel
-        local frame = HCS_MessageFrameUI.DisplayLevelingMessage(msg, 10)
+        local frame = HCS_MessageFrameUI.DisplayLevelingMessage(msg, 5)
         frame:ShowMessage()
       end
     
@@ -170,15 +166,13 @@ function HCS_CalculateScore:RefreshScores(desc)
     if HCS_GameVersion < 30000 then
         levelScalePercentage = (UnitLevel("player")  / 60) -- Classic
     else
-        levelScalePercentage = (UnitLevel("player")  / 80)  -- WOTLK
+        levelScalePercentage = (UnitLevel("player")  / 80) -- WOTLK
     end
 
     _G["CurrentXP"] = UnitXP("player")  -- CurrentXP
     _G["CurrentMaxXP"] = UnitXPMax("player") -- CurrentMaxXP
 
     SetBeforeStats()
-
-    HCS_MilestonesScore:CheckMilestones()
 
     HCScore_Character.scores.levelingScore = HCS_PlayerLevelingScore:GetLevelScore() * levelScalePercentage
     HCScore_Character.scores.equippedGearScore = HCS_PlayerEquippedGearScore:GetEquippedGearScore() * levelScalePercentage
@@ -190,7 +184,7 @@ function HCS_CalculateScore:RefreshScores(desc)
     HCScore_Character.scores.mobsKilledScore = HCS_KillingMobsScore:GetMobsKilledScore()
     HCScore_Character.scores.coreScore = HCS_PlayerCoreScore:GetCoreScore()
 
-
+    HCS_MilestonesScore:CheckMilestones()
     UpdateProfileScores()
     RefreshUI()
     CurrentPortrait = GetCurrentPortrait()

--- a/Core/HCS_MilestonesScore.lua
+++ b/Core/HCS_MilestonesScore.lua
@@ -34,7 +34,7 @@ local function AddMilestone(id)
 
                 if Hardcore_Score.db.profile.framePositionMsg.show then
                     local desc = string.upper(milestone.shortdesc)
-                    local frame = HCS_MessageFrameUI.DisplayMilestoneMessage(desc, milestone.image, 10)
+                    local frame = HCS_MessageFrameUI.DisplayMilestoneMessage(desc, milestone.image, 5)
                     frame:ShowMessage() 
                 end
             end

--- a/Core/HCS_PlayerCom.lua
+++ b/Core/HCS_PlayerCom.lua
@@ -131,7 +131,7 @@ local function ModifyTooltip(self)
         local questing = score.questingScore
         local mobsKilled = score.mobsKilledScore
         local professions = score.professionsScore
-        local reputation = score.reputationScorez
+        local reputation = score.reputationScore
         local discovery = score.discoveryScore
         local milestones = score.milestoneScore
 

--- a/Data/HCS_MilestonesDB.lua
+++ b/Data/HCS_MilestonesDB.lua
@@ -323,7 +323,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 5 mob types",
       shortdesc = "Killed 5 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_2",
@@ -331,7 +331,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 10 mob types",
       shortdesc = "Killed 10 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_3",
@@ -339,7 +339,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 20 mob types",
       shortdesc = "Killed 20 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     },
     {
       id = "mobkt_4",
@@ -347,7 +347,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 30 mob types",
       shortdesc = "Killed 30 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_5",
@@ -355,7 +355,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 40 mob types",
       shortdesc = "Killed 40 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_6",
@@ -363,7 +363,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 50 mob types",
       shortdesc = "Killed 50 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_7",
@@ -371,7 +371,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 60 mob types",
       shortdesc = "Killed 60 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_8",
@@ -379,7 +379,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 70 mob types",
       shortdesc = "Killed 70 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_9",
@@ -387,7 +387,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 80 mob types",
       shortdesc = "Killed 80 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_10",
@@ -395,7 +395,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 90 mob types",
       shortdesc = "Killed 90 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     }, 
     {
       id = "mobkt_11",
@@ -403,7 +403,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 100 mob types",
       shortdesc = "Killed 100 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     },
 
     -- Added in version 0.9.9
@@ -413,7 +413,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 110 mob types",
       shortdesc = "Killed 110 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     },
     {
       id = "mobkt_13",
@@ -421,7 +421,7 @@ HCS_MilestonesDB = {
       desc = "Milestone! Congrats! You've killed 120 mob types",
       shortdesc = "Killed 120 mob types",
       points = mobKillsPoints,
-      image = imgKillingMobs,
+      image = imgKillingMobsType,
     },
 
     -- Total Quests Milestones

--- a/Hardcore_Score.lua
+++ b/Hardcore_Score.lua
@@ -7,7 +7,7 @@ local _;
 Hardcore_Score = {}
 
 -- Globals
-HCS_Version = "0.9.10" --GetAddOnMetadata("Hardcore Score", "Version")
+HCS_Version = "0.9.11" --GetAddOnMetadata("Hardcore Score", "Version")
 HCScore_Character = {
     name = "",
     class = "",
@@ -532,7 +532,7 @@ function Hardcore_Score:init(event, name)
         playerName = HCS_Utils:GetTextWithClassColor(HCScore_Character.class, HCScore_Character.name)
 
         -- Print fun stuff for the player
-        print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome "..playerName.." to Hardcore Score v0.9.10.  Lets GO!")
+        print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome "..playerName.." to Hardcore Score v0.9.11.  Lets GO!")
         --print("|cff81b7e9".."Hardcore Score: ".."|r".."Psst,", playerName.. "! "..  string.format("%.2f", HCS_PlayerCoreScore:GetCoreScore()).. " is a great score!");   
     end
 

--- a/Hardcore_Score_Vanilla.toc
+++ b/Hardcore_Score_Vanilla.toc
@@ -1,8 +1,8 @@
-## Interface: 20500  -- This indicates the addon is compatible up to the WOTLK client.
-## Title: Hardcore Score 0.9.10
+## Interface: 11403
+## Title: Hardcore Score 0.9.11
 ## Notes: Your Hardcore score for your character
 ## Author: Avenroot
-## Version: 0.9.10
+## Version: 0.9.11
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/Hardcore_Score_Wrath.toc
+++ b/Hardcore_Score_Wrath.toc
@@ -1,0 +1,51 @@
+## Interface: 30402
+## Title: Hardcore Score 0.9.11
+## Notes: Your Hardcore score for your character
+## Author: Avenroot
+## Version: 0.9.11
+## DefaultState: enabled
+## SavedVariables: Hardcore_Score_Settings
+## SavedVariablesPerCharacter: HCScore_Character
+## X-Curse-Project-ID: 873836
+## X-Website: https://avenroothcs.wixsite.com/hardcore-score
+
+embeds.xml
+
+Core/HCS_Utils.lua
+Core/HCS_Globals.lua
+Core/HCS_Playerinfo.lua
+Core/HCS_PlayerCoreScore.lua
+Core/HCS_PlayerLevelingScore.lua
+Core/HCS_PlayerEquippedGearScore.lua
+Core/HCS_PlayerHCAchievementScore.lua
+Core/HCS_PlayerQuestingScore.lua
+Core/HCS_KillingMobsScore.lua
+Core/HCS_ProfessionsScore.lua
+Core/HCS_ReputationScore.lua
+Core/HCS_DiscoveryScore.lua
+Core/HCS_PlayerCom.lua
+Core/HCS_CalculateScore.lua
+Core/HCS_MilestonesScore.lua
+
+Events/HCS_PlayerLevelingUpEvent.lua
+Events/HCS_PlayerEquippingItemEvent.lua
+Events/HCS_PlayerCompletingQuestEvent.lua
+Events/HCS_KillingMobsEvent.lua
+Events/HCS_ProfessionsEvent.lua
+Events/HCS_ReputationEvent.lua
+Events/HCS_PlayerDiscoveryEvent.lua
+Events/HCS_XPUpdateEvent.lua
+Events/HCS_DeathEvent.lua
+
+Data/HCS_MilestonesDB.lua
+
+UI/HCS_MainInfoFrameUI.lua
+UI/HCS_ScoreboardSummaryUI.lua
+UI/HCS_PointsLogUI.lua
+UI/HCS_CharactersInfoUI.lua
+UI/HCS_MessageFrameUI.lua
+UI/HCS_WelcomeUI.lua
+
+Hardcore_Score.lua
+
+

--- a/Updates.txt
+++ b/Updates.txt
@@ -54,3 +54,8 @@ Version 0.9.10
     1. Overhauled the visuals for Milestones.
     2. Added support for WOTLK. Adjusted calculations to support level 80.
     3. Fixed leveling display when leveling via turning in a quest (I hope). 
+
+Version 0.9.11
+    1. Set Milestone message popup to display 5 seconds instead of 10 seconds.
+    2. Fixed a bug when hovering over another player's portrait to see their scores.
+    3. Milestone Kill Type was showing the wrong image.  Fixed.


### PR DESCRIPTION
Version 0.9.11
    1. Set Milestone message popup to display 5 seconds instead of 10 seconds.
    2. Fixed a bug when hovering over another player's portrait to see their scores.
    3. Milestone Kill Type was showing the wrong image.  Fixed.