### PR TITLE
Release 1.1.1

### DIFF
--- a/Core/HCS_DiscoveryScore.lua
+++ b/Core/HCS_DiscoveryScore.lua
@@ -16,6 +16,8 @@ function HCS_DiscoveryScore:UpdateDiscoveryScore()
         -- Modify the XP gained based on player's level and game version
         if HCS_GameVersion < 30000 and UnitLevel("player") == 60 then
             xpGained = 150
+        elseif HCS_SODVersion == true and UnitLevel("player") == 25 then  -- Current level 25 for Season of Discovery
+            xpGained = math.random(10, 50)
         elseif HCS_GameVersion >= 30000 and UnitLevel("player") == 80 then
             xpGained = 250
         end

--- a/Core/HCS_Globals.lua
+++ b/Core/HCS_Globals.lua
@@ -2,6 +2,7 @@ HCS_Globals = {}
 
 -- Game information
 HCS_GameVersion = select(4, GetBuildInfo())  -- if over 3000 than playing WOTLK
+HCS_SODVersion, HCS_SODRealm = HCS_Utils:IsSeasonOfDiscoveryServer()
 
 -- Scaling Percentage
 HCS_LevelScalePercentage = 0

--- a/Core/HCS_KillingMobsScore.lua
+++ b/Core/HCS_KillingMobsScore.lua
@@ -8,15 +8,18 @@ local function GetMobKillHCScore(mobLevel)
     local playerLevel = UnitLevel("player")
     local xpGain = 0
     
-    --local xpGain = HCS_XPUpdateEvent:GetXPGain() -- Gives the current XP gain
-
-
     -- Initialize xpGain with the default method
     xpGain = HCS_XPUpdateEvent:GetXPGain()  
-
+ 
     -- Modify the XP reward based on the player's level and game version
+    -- Classic
     if HCS_GameVersion < 30000 and playerLevel == 60 then
         xpGain = 300
+    -- Classic - Season of Discovery
+    elseif HCS_SODVersion == true and playerLevel == 25 and xpGain == 0 then 
+        xpGain = math.random(10, 75)
+        --print("XP Gain: " .. xpGain)
+    -- WOTLK
     elseif HCS_GameVersion >= 30000 and playerLevel == 80 then  -- WOTLK
         xpGain = 400
     end

--- a/Core/HCS_Utils.lua
+++ b/Core/HCS_Utils.lua
@@ -222,6 +222,21 @@ function HCS_Utils:AddThousandsCommas(inputString)
     return formattedString    
 end   
 
+function HCS_Utils:IsSeasonOfDiscoveryServer()
+    local realmName = GetRealmName()
+    local discoveryServers = {
+        "Lava Lash", "Chaos Bolt", "Crusader Strike", "Lone Wolf", "Wild Growth", "Living Flame", "Penance", "Shadowstrike"
+    }
+
+    for _, server in ipairs(discoveryServers) do
+        if realmName == server then
+            return true, realmName
+        end
+    end
+
+    return false, realmName
+end
+
 -- Define a consistent structure for character information
 local function CreateCharacter(charName, charClass, charLevel, coreScore, hasDied, lastOnline, guildName)
     -- Set default values if they are not provided

--- a/Events/HCS_PlayerCompletingQuestEvent.lua
+++ b/Events/HCS_PlayerCompletingQuestEvent.lua
@@ -24,7 +24,7 @@ end
 
 local function OnQuestTurnedIn(event, questEvent, questID, xpReward, moneyReward)
 
--- a hack for Discovery until I can figure out how to detect if any xp is gained by entering a new zone.
+  -- a hack for Discovery until I can figure out how to detect if any xp is gained by entering a new zone.
   _G["ZoneChanged"] = false
 
   questLevel = select(2, GetQuestLogTitle(GetQuestLogIndexByID(questID)))
@@ -35,6 +35,11 @@ local function OnQuestTurnedIn(event, questEvent, questID, xpReward, moneyReward
     -- Classic version
     if playerLevel == 60 then
         xpReward = 1000
+    end
+  elseif HCS_SODVersion == true then
+    -- Classic - Season of Discovery
+    if playerLevel == 25 and xpReward == 0 then 
+        xpReward = math.random(50, 150)
     end
   elseif HCS_GameVersion >= 30000 then
     -- WOTLK

--- a/Hardcore_Score.lua
+++ b/Hardcore_Score.lua
@@ -7,7 +7,7 @@ local _;
 Hardcore_Score = {}
 
 -- Globals
-HCS_Version = "1.1.0" --GetAddOnMetadata("Hardcore Score", "Version")
+HCS_Version = "1.1.1" --GetAddOnMetadata("Hardcore Score", "Version")
 HCS_Release = 20
 HCScore_Character = {
     name = "",
@@ -296,7 +296,7 @@ local options = {
             order = 21
         },
         addonInfoNote = {
-            name = "version 1.1.0 - authors: Avenroot, Caith - level 60 testing Fruze",
+            name = "version 1.1.1 - authors: Avenroot, Caith, Fruze (level 60 testing)",
             desc = "Addon Information",
             type = "description",
             fontSize = "medium",
@@ -662,8 +662,8 @@ function Hardcore_Score:init(event, name)
         HCScore_Character.guildName = GetGuildInfo("player") or ""  --print("Guild: ", GetGuildInfo("player"))
 
         -- Print fun stuff for the player
-        print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome "..playerName.." to Hardcore Score v1.1.0.0  Lets GO!")
-                      
+        print("|cff81b7e9".."Hardcore Score: ".."|r".."Welcome "..playerName.." to Hardcore Score v1.1.1.0  Lets GO!")
+   
     end
 
 end

--- a/Hardcore_Score_Vanilla.toc
+++ b/Hardcore_Score_Vanilla.toc
@@ -1,8 +1,8 @@
 ## Interface: 11500
-## Title: Hardcore Score 1.1.0
+## Title: Hardcore Score 1.1.1
 ## Notes: Your Hardcore score for your character
 ## Author: Avenroot, Caith
-## Version: 1.1.0
+## Version: 1.1.1
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/Hardcore_Score_Wrath.toc
+++ b/Hardcore_Score_Wrath.toc
@@ -1,8 +1,8 @@
 ## Interface: 30403
-## Title: Hardcore Score 1.1.0
+## Title: Hardcore Score 1.1.1
 ## Notes: Your Hardcore score for your character
 ## Author: Avenroot, Caith
-## Version: 1.1.0
+## Version: 1.1.1
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/Updates.txt
+++ b/Updates.txt
@@ -134,3 +134,8 @@ Version 1.1.0
     8. Updated for version 1.1.5 of Classic Era 
     9. Updated for version 3.4.3 of Classic Era (WOTLK)
 
+Version 1.1.1
+    Changes to XP amounts when you reach level 25 in Season of Discovery to get points.  Before none was given.  
+        1. Level 25 Classic - Season of Discovery now gives XP for mob kills when level 25.  XP is a random number between 10-75.
+        2. Level 25 Classic - Season of Discovery now gives XP for quests when level 25.  XP is a random number between 50-150.
+        3. Level 25 Classic - Season of Discovery now gives XP for discoveries when level 25.  XP is a random number between 10-50.


### PR DESCRIPTION
 Changes to XP amounts when you reach level 25 in Season of Discovery to get points.  Before none was given.
        1. Level 25 Classic - Season of Discovery now gives XP for mob kills when level 25.  XP is a random number between 10-75.
        2. Level 25 Classic - Season of Discovery now gives XP for quests when level 25.  XP is a random number between 50-150.
        3. Level 25 Classic - Season of Discovery now gives XP for discoveries when level 25.  XP is a random number between 10-50.