### PR TITLE
Sync 1.2.0.4 changelog so release notes show in-game

### DIFF
--- a/Data/HCS_Updates.lua
+++ b/Data/HCS_Updates.lua
@@ -220,6 +220,11 @@ Version 1.2.0.2
 
 Version 1.2.0.3
 1. Maintainence update for 11508
+
+Version 1.2.0.4
+1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
+2. Update for 11509 (Classic Era 1.15.9).
+3. Fixed some errors that could show up when mob kill data hadn't finished loading yet.
 ]]
 
 local function trim(s)

--- a/Updates.txt
+++ b/Updates.txt
@@ -216,4 +216,6 @@ Version 1.2.0.3
 1. Maintainence update for 11508
 
 Version 1.2.0.4
-1. Removed all support for WotLK and Cataclysm.
+1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
+2. Update for 11509 (Classic Era 1.15.9).
+3. Fixed some errors that could show up when mob kill data hadn't finished loading yet.


### PR DESCRIPTION
Follow-up to #58.

## Problem

`Updates.txt` had a 1.2.0.4 entry but `Data/HCS_Updates.lua` stopped at 1.2.0.3. The addon reads the embedded Lua copy at runtime (WoW's sandbox can't read plain text files), so `HCS_Updates:GetTopLinesFor("1.2.0.4", 3)` returned nil and the update banner fell back to the generic "Thanks for updating Classic Score!" text.

## Fix

Adds the 1.2.0.4 block to the Lua copy and expands the entry in both files so it reflects what actually shipped:

1. Removed all support for WotLK and Cataclysm - Classic Era only from here on
2. Update for 11509 (Classic Era 1.15.9)
3. Fixed some errors that could show up when mob kill data hadn't finished loading yet

Item 3 covers the nil guards added around `HCS_KillingMobsScore` lookups. The Cata-specific removals (1.33 points multiplier, `/85` level scaling, level-85 XP branches, Jewelcrafting/Inscription, profession skill above 300) are deliberately not called out as score changes - Classic Era players were never affected by any of them.

Both files verified identical for the 1.2.0.4 block, and the entry has exactly 3 numbered items to match the `count` the caller requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)