### PR TITLE
Reconcile 1.2.0.2 changelog drift

### DIFF
--- a/Data/HCS_Updates.lua
+++ b/Data/HCS_Updates.lua
@@ -217,6 +217,7 @@ Version 1.2.0.2
 1. Major update!  Enhanced public Leaderboard features. Open the SCORE BOARD (right click on the mini map button) and Check it out!!
 2. Level 60 characters now get points for elite mob kills.  Other points enhancements for level 60.
 3. Lots of changes to the Character Journey information, including tracking lowest health/deaths.
+4. Fixed bug when accessing the Leaderboard Tab. If you can't read the character rank, it will crash the Leaderboard list.
 
 Version 1.2.0.3
 1. Maintainence update for 11508

--- a/Updates.txt
+++ b/Updates.txt
@@ -206,11 +206,10 @@ Version 1.2.0.1
 1. Fix for public Leaderboard.  Now working correctly.  Don't need to be part of a group/guild/raid to share score.
 
 Version 1.2.0.2
-1. Major update! Enhanced public Leaderboard features. Check it out!!
-2. Level 60 characters now get points for elite mob kills. Other points enhancements for level 60.
+1. Major update!  Enhanced public Leaderboard features. Open the SCORE BOARD (right click on the mini map button) and Check it out!!
+2. Level 60 characters now get points for elite mob kills.  Other points enhancements for level 60.
 3. Lots of changes to the Character Journey information, including tracking lowest health/deaths.
 4. Fixed bug when accessing the Leaderboard Tab. If you can't read the character rank, it will crash the Leaderboard list.
-5. Lots of changes to the Character Journey information, including tracking lowest health/deaths.
 
 Version 1.2.0.3
 1. Maintainence update for 11508


### PR DESCRIPTION
Follow-up to #59, which synced 1.2.0.4 but left pre-existing 1.2.0.2 drift in place.

## Problem

`Updates.txt` and the embedded `HCS_Updates.Raw` block had diverged for 1.2.0.2, and each side held something the other was missing:

| | `Updates.txt` | `HCS_Updates.lua` |
|---|---|---|
| Item 1 | Short version | Fuller - explains how to open the Score Board |
| Item 4 (Leaderboard crash fix) | Present | **Missing** |
| Item 5 | Verbatim duplicate of item 3 | Absent |

## Fix

Takes the union minus the duplicate:

1. Item 1 adopts the Lua copy's wording, which tells players to right click the minimap button to open the SCORE BOARD.
2. Item 4 (Leaderboard Tab crash fix) added to the Lua copy.
3. Item 5 dropped as a duplicate of item 3.

## Verification

Extracted the `HCS_Updates.Raw` block and diffed it against `Updates.txt` in full: **byte-identical across all 220 lines**, down from 6 differing lines. The Lua long-bracket string still has exactly one `]]` terminator.

Note that `GetTopLinesFor` only surfaces the top 3 items in-game, so item 4 won't appear in the 1.2.0.2 banner - this is about keeping the written record correct and the two sources honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)