### PR TITLE
Fix SetFont error spam on the Score Board

### DIFF
--- a/Data/HCS_Updates.lua
+++ b/Data/HCS_Updates.lua
@@ -225,7 +225,7 @@ Version 1.2.0.3
 Version 1.2.0.4
 1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
 2. Update for 11509 (Classic Era 1.15.9).
-3. Fixed some errors that could show up when mob kill data hadn't finished loading yet.
+3. Fixed Lua errors on the Score Board, and errors that could show up when mob kill data hadn't finished loading yet.
 ]]
 
 local function trim(s)

--- a/UI/HCS_LeaderBoardUI.lua
+++ b/UI/HCS_LeaderBoardUI.lua
@@ -185,7 +185,7 @@ local function CreateRowForLeaderBoard(row, position, name, score, level, classi
             text = HCS_LeaderBoardUI.frame:CreateFontString(nil, "OVERLAY")
             --text:SetFont("Fonts\\FRIZQT__.TTF", 12, "OUTLINE")
             local font, _, flags = text:GetFont()
-            text:SetFont(fontPath, fontSize, 14, flags) -- Set the desired font size (14 in this example)                
+            text:SetFont(fontPath, fontSize, flags) -- Set the desired font size (14 in this example)
             rowTable[i] = text
         end
         text:SetPoint("TOPLEFT", HCS_LeaderBoardUI.frame, "TOPLEFT", offset, -60 -row * 20)

--- a/Updates.txt
+++ b/Updates.txt
@@ -217,4 +217,4 @@ Version 1.2.0.3
 Version 1.2.0.4
 1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
 2. Update for 11509 (Classic Era 1.15.9).
-3. Fixed some errors that could show up when mob kill data hadn't finished loading yet.
+3. Fixed Lua errors on the Score Board, and errors that could show up when mob kill data hadn't finished loading yet.


### PR DESCRIPTION
Fixes a Lua error reported on load against Classic Era 1.15.9 (43 occurrences per login).

## The error

```
HCS_LeaderBoardUI.lua:188: bad argument #3 to 'SetFont'
(supported flags: OUTLINE, THICKOUTLINE, MONOCHROME, FILTER, FIXEDHEIGHT, NEVERCULL, SLUG
 - Usage: local success = self:SetFont(fontFile, fontHeight [, flags]))
```

## Cause

Line 188 passed **four** arguments to a three-argument function:

```lua
text:SetFont(fontPath, fontSize, 14, flags)
```

`SetFont` is `(fontFile, fontHeight [, flags])`, so the stray `14` occupied the flags slot and the client rejected it as an invalid flag string. The error locals confirm it — `fontSize=14` was already being passed as argument #2.

The line is a copy-paste of line 166 (which is correct, and carries the same trailing comment) with an extra `14` left in. It fires inside the per-cell loop of `CreateRowForLeaderBoard`, which is why it repeated 43 times.

## Fix

Drop the stray `14`, making line 188 identical to the working line 166:

```lua
text:SetFont(fontPath, fontSize, flags)
```

## Verification

- Swept every `SetFont` call in the addon: this was the **only** one with four arguments; the other ~130 all pass three or two. Zero 4-argument calls remain.
- Line 166 uses this exact form and does not error - execution reaching line 188 proves it succeeds with the same `flags=""` value.
- Confirmed `Fonts/BebasNeue-Regular.ttf` exists on disk (60,576 bytes), so `fontPath` and `fontSize` were never at fault.

## Changelog

Folded into the existing 1.2.0.4 item 3 rather than added as a fourth item, since `GetTopLinesFor` only surfaces the top 3 in the in-game banner. Both changelog sources verified still byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)