### PR TITLE
Guard leaderboard score compares and clear stale rank numbers

### DIFF
--- a/Core/HCS_PlayerCom.lua
+++ b/Core/HCS_PlayerCom.lua
@@ -344,7 +344,7 @@ f:SetScript("OnEvent", function(self, event, ...)
                             local incomingCoreScore = tonumber(scoreReveived.coreScore) or 0
                             
                             -- Check if incoming coreScore is higher than existing coreScore
-                            if incomingCoreScore > tonumber(HCScore_Character.leaderboard[scoreReveived.charName].coreScore) then
+                            if incomingCoreScore > (tonumber(HCScore_Character.leaderboard[scoreReveived.charName].coreScore) or 0) then
                                 HCScore_Character.leaderboard[scoreReveived.charName].coreScore = scoreReveived.coreScore
                                 -- Provide default values if nil
                                 HCScore_Character.leaderboard[scoreReveived.charName].hasDied = scoreReveived.hasDied or 0
@@ -422,7 +422,7 @@ f:SetScript("OnEvent", function(self, event, ...)
                     end
                     if HCScore_Character.leaderboard[scoreReveived.charName] then
                         local incomingCoreScore = tonumber(scoreReveived.coreScore) or 0
-                        if incomingCoreScore > tonumber(HCScore_Character.leaderboard[scoreReveived.charName].coreScore) then
+                        if incomingCoreScore > (tonumber(HCScore_Character.leaderboard[scoreReveived.charName].coreScore) or 0) then
                             HCScore_Character.leaderboard[scoreReveived.charName].coreScore = scoreReveived.coreScore
                             HCScore_Character.leaderboard[scoreReveived.charName].hasDied = scoreReveived.hasDied or 0
                             HCScore_Character.leaderboard[scoreReveived.charName].lastOnline = scoreReveived.lastOnline or date("%Y-%m-%d %H:%M:%S")

--- a/UI/HCS_LeaderBoardUI.lua
+++ b/UI/HCS_LeaderBoardUI.lua
@@ -232,6 +232,9 @@ function HCS_LeaderBoardUI:LoadData()
         for _, text in ipairs(row) do
             text:SetText("")
         end
+        if row[0] then
+            row[0]:SetText("") -- ipairs starts at 1, so clear the position number too
+        end
     end
 
     -- Convert the leaderboard to an array


### PR DESCRIPTION
Follow-up to #61. Fixing the `SetFont` error made `CreateRowForLeaderBoard` complete for the first time on this client, so the leaderboard path became reachable and worth sweeping. Two issues found.

## 1. Unguarded nil compare (crash)

`HCS_PlayerCom.lua:347` and `:425` — same bug in two places. Only the left side was nil-guarded:

```lua
local incomingCoreScore = tonumber(scoreReveived.coreScore) or 0   -- guarded
if incomingCoreScore > tonumber(...leaderboard[...].coreScore) then -- not guarded
```

If a stored entry's `coreScore` isn't numeric, `tonumber` returns nil and this throws `attempt to compare number with nil`. Triggered by receiving a score from another player. Both sides now guarded.

## 2. Stale rank numbers (display)

`HCS_LeaderBoardUI.lua:231` cleared rows with `ipairs`, which starts at index 1 — but the position text is stored at index `0`. Rows left over from a longer list kept their rank numbers visible while their data columns blanked. `ClearRow` already handled index 0 correctly; `LoadData` now matches it.

The same `ipairs` pattern appears in `LoadDataNearChar`, but there it's immediately followed by `ClearRow(i)` calls that do clear index 0 — redundant rather than broken, so left untouched.

## Also swept, no changes needed

- All ~130 other `SetFont` calls pass 3 or 2 arguments; #61 was genuinely isolated.
- Every `SetBackdrop` is on a frame created with `"BackdropTemplate"`.
- No namespace migrations needed — `GetQuestLogTitle`, `GetFactionInfo`, `GetNumFactions`, `GetQuestLogIndexByID` and `LoadAddOn` are all still in use by other current addons in the same 1.15.9 install.
- `UpsertSelfIntoLeaderboard` already guards the player's own entry.

## Known, not addressed here

Stored `coreScore` is inconsistently typed — new entries (line 362) store a number, updates (348/426) store the raw string off the wire. That's what makes issue 1 reachable. The guards neutralize the crash; normalizing the storage is a separate cleanup.

## Verification

Verified in-game on Classic Era 1.15.9: clean reload, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)