### PR TITLE
Make Score Board presence stable and live by default

### DIFF
--- a/Core/HCS_Globals.lua
+++ b/Core/HCS_Globals.lua
@@ -176,6 +176,9 @@ HCS_Leaderboard_Filtered = {}
 
 -- Public network presence tracking
 HCS_PublicOnline = {}
-HCS_PublicPresenceWindow = 180 -- seconds to consider someone "online" after last ping
+-- Seconds to consider someone "online" after last ping. The public heartbeat
+-- sends every 120s, so this allows two missed/throttled beats before a player
+-- drops off. At 180 a single delayed message made players pop in and out.
+HCS_PublicPresenceWindow = 300
 HCS_PublicAnnounced = false
 HCS_DebugCom = false -- enable verbose comm diagnostics

--- a/Data/HCS_Updates.lua
+++ b/Data/HCS_Updates.lua
@@ -224,8 +224,9 @@ Version 1.2.0.3
 
 Version 1.2.0.4
 1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
-2. Update for 11509 (Classic Era 1.15.9).
+2. Score Board live view is steadier.  Players no longer pop in and out, players who log off now clear on their own, and "Only live" is on by default.
 3. Fixed Lua errors on the Score Board, and errors that could show up when mob kill data hadn't finished loading yet.
+4. Update for 11509 (Classic Era 1.15.9).
 ]]
 
 local function trim(s)

--- a/Hardcore_Score.lua
+++ b/Hardcore_Score.lua
@@ -513,7 +513,7 @@ function Hardcore_Score:CreateDB()
             shareDetails = true,
             sharePublic = true,
             publicChannelName = "ClassicScore",
-            onlyLive = false,
+            onlyLive = true,
             keepHistory = true,
             historyDays = 30,
             shareMilestones = true,

--- a/UI/HCS_LeaderBoardUI.lua
+++ b/UI/HCS_LeaderBoardUI.lua
@@ -392,3 +392,18 @@ function HCS_LeaderBoardUI:LoadDataNearChar()
     end
 
 end
+
+-- Re-evaluate presence on a timer while the Score Board is open.
+-- isOnlineNow() is only computed during a redraw, and redraws are otherwise
+-- driven by incoming addon messages. Without this, once traffic stops nothing
+-- clears players who have logged off, and with onlyLive enabled they linger on
+-- the board indefinitely. Local only - this sends nothing.
+if C_Timer and C_Timer.NewTicker then
+    C_Timer.NewTicker(30, function()
+        local profile = Hardcore_Score and Hardcore_Score.db and Hardcore_Score.db.profile
+        if not profile or not profile.sharePublic then return end
+        if HCS_LeaderBoardUI.frame and HCS_LeaderBoardUI.frame:IsShown() then
+            HCS_LeaderBoardUI:RefreshData()
+        end
+    end)
+end

--- a/Updates.txt
+++ b/Updates.txt
@@ -216,5 +216,6 @@ Version 1.2.0.3
 
 Version 1.2.0.4
 1. Removed all support for WotLK and Cataclysm.  Classic Era only from here on.
-2. Update for 11509 (Classic Era 1.15.9).
+2. Score Board live view is steadier.  Players no longer pop in and out, players who log off now clear on their own, and "Only live" is on by default.
 3. Fixed Lua errors on the Score Board, and errors that could show up when mob kill data hadn't finished loading yet.
+4. Update for 11509 (Classic Era 1.15.9).


### PR DESCRIPTION
Players were popping in and out of the live Score Board. Confirmed real, not a display illusion.

## Why they vanished

With `onlyLive` enabled, [HCS_LeaderBoardUI.lua:283](UI/HCS_LeaderBoardUI.lua) doesn't merely re-sort by presence — it **filters offline players out of the array entirely**. So a player falling outside the presence window disappears from the board rather than dropping down it.

The public heartbeat sends every 120s against a 180s window — 60s of slack. One throttled or delayed message (sends route through ChatThrottleLib and are gated by `publicSendsReadyAt`) puts a player at 240s, past the window, and they vanish until their next beat.

It felt random because redraws are driven by *incoming messages*, so whether a given player was present depended on when someone **else's** message happened to trigger a redraw relative to that player's last beat.

## Changes

1. **`HCS_PublicPresenceWindow` 180s → 300s** — tolerates two missed beats instead of zero. No extra channel traffic.
2. **30s presence ticker** in `HCS_LeaderBoardUI` — `isOnlineNow()` is only computed during a redraw, so once traffic stopped nothing cleared players who had logged off; with `onlyLive` on they lingered indefinitely. Guarded to run only while the board is shown and `sharePublic` is on. Local only, sends nothing.
3. **`onlyLive` now defaults to true** — the board shows live players out of the box.

## Note on the default flip

AceDB doesn't persist values equal to the default. Anyone whose `onlyLive` was `false` — whether untouched or deliberately unchecked — has nothing saved, so both groups switch on at next login; the two cases are indistinguishable in saved data. Inherent to changing a default, and self-correcting afterward: once the default is `true`, unchecking writes `false` and sticks.

Also worth knowing: with `onlyLive` on, a user in a quiet area sees only themselves, since saved-history players are filtered out. That is what "only live" means, but it can read as an empty board.

## Verification

Verified in-game on Classic Era 1.15.9 — clean reload, no popping observed. Changelog updated in both sources and verified byte-identical; the live-view item was moved to position 2 so it appears in the in-game banner, which shows only the top 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)